### PR TITLE
Use a ContentObserver.

### DIFF
--- a/MediaStore/app/src/main/java/com/android/samples/mediastore/MainActivity.kt
+++ b/MediaStore/app/src/main/java/com/android/samples/mediastore/MainActivity.kt
@@ -69,13 +69,7 @@ class MainActivity : AppCompatActivity() {
 
         if (!haveStoragePermission()) {
             binding.welcomeView.visibility = View.VISIBLE
-        }
-    }
-
-    override fun onResume() {
-        super.onResume()
-
-        if (haveStoragePermission()) {
+        } else {
             showImages()
         }
     }


### PR DESCRIPTION
Update to using a ContentObserver to watch for changes to the Media
Store rather than reloading in `onResume`.

Fixes #25