### PR TITLE
Add "delete" functionality.

### DIFF
--- a/MediaStore/app/src/main/AndroidManifest.xml
+++ b/MediaStore/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~ Copyright (C) 2019 The Android Open Source Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/MediaStore/app/src/main/AndroidManifest.xml
+++ b/MediaStore/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (C) 2019 The Android Open Source Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +19,9 @@
     package="com.android.samples.mediastore">
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 
     <application
         android:allowBackup="true"

--- a/MediaStore/app/src/main/java/com/android/samples/mediastore/MainActivity.kt
+++ b/MediaStore/app/src/main/java/com/android/samples/mediastore/MainActivity.kt
@@ -46,7 +46,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 private const val READ_EXTERNAL_STORAGE_REQUEST = 0x1045
 
 /**
- * Code used witn [IntentSender] to request user permission to delete an image with scoped storage.
+ * Code used with [IntentSender] to request user permission to delete an image with scoped storage.
  */
 private const val DELETE_PERMISSION_REQUEST = 0x1033
 
@@ -77,12 +77,20 @@ class MainActivity : AppCompatActivity() {
         })
 
         viewModel.permissionNeededForDelete.observe(this, Observer { intentSender ->
-            intentSender?.let { sender ->
+            intentSender?.let {
                 // On Android 10+, if the app doesn't have permission to modify
                 // or delete an item, it returns an `IntentSender` that we can
                 // use here to prompt the user to grant permission to delete (or modify)
                 // the image.
-                startIntentSenderForResult(sender, DELETE_PERMISSION_REQUEST, null, 0, 0, 0, null)
+                startIntentSenderForResult(
+                    intentSender,
+                    DELETE_PERMISSION_REQUEST,
+                    null,
+                    0,
+                    0,
+                    0,
+                    null
+                )
             }
         })
 
@@ -138,9 +146,7 @@ class MainActivity : AppCompatActivity() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (resultCode == Activity.RESULT_OK && requestCode == DELETE_PERMISSION_REQUEST) {
-            viewModel.pendingDeleteImage?.let { image ->
-                viewModel.deleteImage(image)
-            }
+            viewModel.deletePendingImage()
         }
     }
 
@@ -197,14 +203,13 @@ class MainActivity : AppCompatActivity() {
 
     private fun deleteImage(image: MediaStoreImage) {
         MaterialAlertDialogBuilder(this)
-            .setTitle(R.string.delete_title)
-            .setMessage(getString(R.string.delete_message, image.displayName))
-            .setPositiveButton(R.string.delete_positive) { _: DialogInterface, _: Int ->
+            .setTitle(R.string.delete_dialog_title)
+            .setMessage(getString(R.string.delete_dialog_message, image.displayName))
+            .setPositiveButton(R.string.delete_dialog_positive) { _: DialogInterface, _: Int ->
                 viewModel.deleteImage(image)
             }
-            .setNegativeButton(R.string.delete_negative)
-            { _: DialogInterface, _: Int ->
-                // Nothing to do
+            .setNegativeButton(R.string.delete_dialog_negative) { dialog: DialogInterface, _: Int ->
+                dialog.dismiss()
             }
             .show()
     }

--- a/MediaStore/app/src/main/java/com/android/samples/mediastore/MainActivity.kt
+++ b/MediaStore/app/src/main/java/com/android/samples/mediastore/MainActivity.kt
@@ -184,7 +184,10 @@ class MainActivity : AppCompatActivity() {
      */
     private fun requestPermission() {
         if (!haveStoragePermission()) {
-            val permissions = arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+            val permissions = arrayOf(
+                Manifest.permission.READ_EXTERNAL_STORAGE,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+            )
             ActivityCompat.requestPermissions(this, permissions, READ_EXTERNAL_STORAGE_REQUEST)
         }
     }

--- a/MediaStore/app/src/main/java/com/android/samples/mediastore/MainActivityViewModel.kt
+++ b/MediaStore/app/src/main/java/com/android/samples/mediastore/MainActivityViewModel.kt
@@ -18,12 +18,15 @@ package com.android.samples.mediastore
 
 import android.annotation.SuppressLint
 import android.app.Application
+import android.app.RecoverableSecurityException
 import android.content.ContentProvider
 import android.content.ContentResolver
 import android.content.ContentUris
+import android.content.IntentSender
 import android.database.ContentObserver
 import android.database.Cursor
 import android.net.Uri
+import android.os.Build
 import android.os.Handler
 import android.provider.MediaStore
 import android.util.Log
@@ -59,6 +62,40 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
                     MediaStore.Images.Media.EXTERNAL_CONTENT_URI
                 ) {
                     loadImages()
+                }
+            }
+        }
+    }
+
+    suspend fun deleteImage(image: MediaStoreImage): IntentSender? {
+        return withContext(Dispatchers.IO) {
+            try {
+                /**
+                 * In [Build.VERSION_CODES.Q] and above, it isn't possible to modify
+                 * or delete items in MediaStore directly, and explicit permission
+                 * must usually be obtained to do this.
+                 *
+                 * The way it works is the OS will throw a [RecoverableSecurityException],
+                 * which we can catch here. Inside there's an [IntentSender] which the
+                 * activity can use to prompt the user to grant permission to the item
+                 * so it can be either updated or deleted.
+                 */
+                context.contentResolver.delete(
+                    image.contentUri,
+                    "${MediaStore.Images.Media._ID} = ?",
+                    arrayOf(image.id.toString())
+                )
+
+                // Rename succeeded.
+                null
+            } catch (securityException: SecurityException) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    val recoverableSecurityException =
+                        securityException as? RecoverableSecurityException
+                            ?: throw RuntimeException(securityException.message, securityException)
+                    recoverableSecurityException.userAction.actionIntent.intentSender
+                } else {
+                    throw RuntimeException(securityException.message, securityException)
                 }
             }
         }

--- a/MediaStore/app/src/main/java/com/android/samples/mediastore/MainActivityViewModel.kt
+++ b/MediaStore/app/src/main/java/com/android/samples/mediastore/MainActivityViewModel.kt
@@ -225,7 +225,7 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     val recoverableSecurityException =
                         securityException as? RecoverableSecurityException
-                            ?: throw RuntimeException(securityException.message, securityException)
+                            ?: throw securityException
 
                     // Signal to the Activity that it needs to request permission and
                     // try the delete again if it succeeds.
@@ -234,7 +234,7 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
                         recoverableSecurityException.userAction.actionIntent.intentSender
                     )
                 } else {
-                    throw RuntimeException(securityException.message, securityException)
+                    throw securityException
                 }
             }
         }

--- a/MediaStore/app/src/main/java/com/android/samples/mediastore/MediaStoreImage.kt
+++ b/MediaStore/app/src/main/java/com/android/samples/mediastore/MediaStoreImage.kt
@@ -18,7 +18,7 @@ package com.android.samples.mediastore
 
 import android.net.Uri
 import androidx.recyclerview.widget.DiffUtil
-import java.util.Date
+import java.util.*
 
 /**
  * Simple data class to hold information about an image included in the device's MediaStore.
@@ -38,6 +38,4 @@ data class MediaStoreImage(
                 oldItem == newItem
         }
     }
-
-    val requestCode get() = ((id and 0x0fff) or 0x1000).toInt()
 }

--- a/MediaStore/app/src/main/java/com/android/samples/mediastore/MediaStoreImage.kt
+++ b/MediaStore/app/src/main/java/com/android/samples/mediastore/MediaStoreImage.kt
@@ -38,4 +38,6 @@ data class MediaStoreImage(
                 oldItem == newItem
         }
     }
+
+    val requestCode get() = ((id and 0x0fff) or 0x1000).toInt()
 }

--- a/MediaStore/app/src/main/res/values/strings.xml
+++ b/MediaStore/app/src/main/res/values/strings.xml
@@ -25,8 +25,8 @@
 
     <string name="permission_not_granted">App requires access to storage to access items stored in MediaStore.</string>
 
-    <string name="delete_title">Delete?</string>
-    <string name="delete_message">Delete %1$s?</string>
-    <string name="delete_positive">Delete</string>
-    <string name="delete_negative">Cancel</string>
+    <string name="delete_dialog_title">Delete?</string>
+    <string name="delete_dialog_message">Delete %1$s?</string>
+    <string name="delete_dialog_positive">Delete</string>
+    <string name="delete_dialog_negative">Cancel</string>
 </resources>

--- a/MediaStore/app/src/main/res/values/strings.xml
+++ b/MediaStore/app/src/main/res/values/strings.xml
@@ -24,4 +24,9 @@
     <string name="grant_permission">Grant Permission</string>
 
     <string name="permission_not_granted">App requires access to storage to access items stored in MediaStore.</string>
+
+    <string name="delete_title">Delete?</string>
+    <string name="delete_message">Delete %1$s?</string>
+    <string name="delete_positive">Delete</string>
+    <string name="delete_negative">Cancel</string>
 </resources>


### PR DESCRIPTION
This adds the ability to tap on an image and delete it, including the
flow for catching a `RecoverableSecurityException` on Android 10+ to
request access to modify or, in this case, delete items in the Media
Store.