### PR TITLE
[FileProvider] Fix crash when adding images

### DIFF
--- a/FileProvider/app/src/main/java/com/example/graygallery/ui/AppViewModel.kt
+++ b/FileProvider/app/src/main/java/com/example/graygallery/ui/AppViewModel.kt
@@ -165,7 +165,7 @@ private fun getAttributesFromXmlNode(
 
                 val attributes = mutableMapOf<String, String>()
 
-                for (index in 0..xml.attributeCount) {
+                for (index in 0 until xml.attributeCount) {
                     attributes[xml.getAttributeName(index)] = xml.getAttributeValue(index)
                 }
 


### PR DESCRIPTION
This fixes the upper endpoint of the `for` loop that reads attribute values of `FileProvider`'s XML configuration file. Without this fix the app crashes with an `IndexOutOfBoundsException`.

Fixes #64