### PR TITLE
[FileProvider] Use VIEW Intent to display gallery image

### DIFF
--- a/FileProvider/app/src/main/java/com/example/graygallery/ui/GalleryFragment.kt
+++ b/FileProvider/app/src/main/java/com/example/graygallery/ui/GalleryFragment.kt
@@ -16,16 +16,20 @@
 
 package com.example.graygallery.ui
 
+import android.content.ActivityNotFoundException
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.GridLayoutManager
 import com.example.graygallery.databinding.FragmentGalleryBinding
 import com.google.android.material.snackbar.Snackbar
+import java.io.File
 
 const val GALLERY_COLUMNS = 3
 
@@ -45,7 +49,7 @@ class GalleryFragment : Fragment() {
 
         val galleryAdapter =
             GalleryAdapter { image ->
-                println("image clicked: $image")
+                viewImageUsingExternalApp(image)
             }
 
         binding.gallery.also { view ->
@@ -67,5 +71,22 @@ class GalleryFragment : Fragment() {
         // TODO: Add popup menu https://material.io/develop/android/components/menu/
         //  https://www.techotopia.com/index.php/Working_with_the_Android_GridLayout_in_XML_Layout_Resources
         return binding.root
+    }
+
+    private fun viewImageUsingExternalApp(imageFile: File) {
+        val context = requireContext()
+        val authority = "${context.packageName}.fileprovider"
+        val contentUri = FileProvider.getUriForFile(context, authority, imageFile)
+
+        val viewIntent = Intent(Intent.ACTION_VIEW).apply {
+            data = contentUri
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+
+        try {
+            startActivity(viewIntent)
+        } catch (e: ActivityNotFoundException) {
+            Snackbar.make(binding.root, "Couldn't find suitable app to display the image", Snackbar.LENGTH_SHORT).show()
+        }
     }
 }


### PR DESCRIPTION
The FileProvider sample should probably make use [`FileProvider`](https://developer.android.com/reference/kotlin/androidx/core/content/FileProvider). So this changes the code to launch the [`ACTION_VIEW`](https://developer.android.com/reference/kotlin/android/content/Intent#action_view) intent when an image in the gallery screen is clicked. `FileProvider` is used to expose the image stored in an app-private storage directory to the external app.

Note: You won't be able to run/test this without applying the fix in #66.