### PR TITLE
Update android.yml

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,9 +16,9 @@ name: Android CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
 


### PR DESCRIPTION
I noticed our external CI is still pointing to the master branch, so I changed to the new default, 'main'.

All PRs are copied over to master from main anyway, so maybe it doesn't matter, but I want to eventually delete main.