### PR TITLE
Removed requestLegacyExternalStorage flag

### DIFF
--- a/FileManager/app/src/main/AndroidManifest.xml
+++ b/FileManager/app/src/main/AndroidManifest.xml
@@ -13,7 +13,6 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:requestLegacyExternalStorage="true"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MyApp">


### PR DESCRIPTION
app to target Android 11, the system ignores the requestLegacyExternalStorage flag.
So, Removed requestLegacyExternalStorage flag.

ref: https://youtu.be/UnJ3amzJM94?t=350
ref: https://developer.android.com/about/versions/11/privacy/storage#scoped-storage