### PR TITLE
Update MediaStore to AGP 4.2.1

### DIFF
--- a/MediaStore/app/build.gradle
+++ b/MediaStore/app/build.gradle
@@ -38,8 +38,8 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-    dataBinding {
-        enabled true
+    buildFeatures {
+        dataBinding true
     }
     kotlinOptions {
         jvmTarget = "1.8"

--- a/MediaStore/build.gradle
+++ b/MediaStore/build.gradle
@@ -18,27 +18,27 @@
 
 buildscript {
     ext {
-        activity_ktx_version = '1.2.0-alpha03'
-        appcompat_version = '1.1.0'
-        constraint_layout_version = '1.1.3'
+        activity_ktx_version = '1.2.3'
+        appcompat_version = '1.3.0'
+        constraint_layout_version = '2.0.4'
         coroutines_version = '1.2.1'
-        espresso_version = '3.2.0'
-        glide_version = '4.9.0'
+        espresso_version = '3.3.0'
+        glide_version = '4.12.0'
         gradleVersion = '3.4.2'
-        junit_version = '4.12'
-        kotlin_version = '1.3.50'
-        material_version = '1.1.0'
+        junit_version = '4.13.2'
+        kotlin_version = '1.4.32'
+        material_version = '1.3.0'
         navigation_version = '2.1.0-beta02'
         recyclerview_version = '1.1.0-beta01'
-        test_runner_version = '1.2.0'
+        test_runner_version = '1.3.0'
         vectordrawable_version = '1.1.0'
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -48,7 +48,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/MediaStore/gradle.properties
+++ b/MediaStore/gradle.properties
@@ -35,4 +35,3 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-android.databinding.enableV2=true

--- a/MediaStore/gradle/wrapper/gradle-wrapper.properties
+++ b/MediaStore/gradle/wrapper/gradle-wrapper.properties
@@ -18,4 +18,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
This is to make MediaStore buildable with Java 11, refer to b/189947245 for the context. PTAL.