### PR TITLE
update mediastore's compileSdkVerrsion to 30

### DIFF
--- a/ActionOpenDocument/build.gradle
+++ b/ActionOpenDocument/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
         espressoVersion = '3.0.1'
         junitVersion = '4.12'
-        kotlinVersion = '1.3.40'
+        kotlinVersion = '1.5.30'
         supportLibVersion = '28.0.0'
         supportTestVersion = '1.0.1'
     }

--- a/ActionOpenDocumentTree/build.gradle
+++ b/ActionOpenDocumentTree/build.gradle
@@ -17,7 +17,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.40'
+    ext.kotlin_version = '1.5.30'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
fix compile error:
```
Execution failed for task ':app:checkDebugAarMetadata'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
   > One or more issues found when checking AAR metadata values:
     
     The minCompileSdk (30) specified in a
     dependency's AAR metadata (META-INF/com/android/build/gradle/aar-metadata.properties)
     is greater than this module's compileSdkVersion (android-29).
     Dependency: androidx.activity:activity-ktx:1.3.1.
     AAR metadata file: /Users/gfan/.gradle/caches/transforms-3/0024c7a14b5c2c68c2105d91922181dc/transformed/jetified-activity-ktx-1.3.1/META-INF/com/android/build/gradle/aar-metadata.properties.
```
very low risk, need for CI. 