### PR TITLE
Update project for Android 33 and replace deprecated code.

### DIFF
--- a/ActionOpenDocumentTree/app/build.gradle
+++ b/ActionOpenDocumentTree/app/build.gradle
@@ -36,6 +36,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'com.example.android.ktfiles'
     /*
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/ActionOpenDocumentTree/app/build.gradle
+++ b/ActionOpenDocumentTree/app/build.gradle
@@ -54,24 +54,24 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
 
-    implementation 'androidx.fragment:fragment:1.3.6'
+    implementation 'androidx.fragment:fragment-ktx:1.5.7'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
 
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
-    implementation 'androidx.recyclerview:recyclerview:1.2.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.recyclerview:recyclerview:1.3.0'
 
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'com.google.android.material:material:1.9.0'
 
     implementation 'androidx.documentfile:documentfile:1.0.1'
 
-    implementation 'androidx.core:core-ktx:1.6.0'
-    implementation 'androidx.fragment:fragment-ktx:1.3.6'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1'
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.fragment:fragment-ktx:1.5.7'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1'
 
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/ActionOpenDocumentTree/app/build.gradle
+++ b/ActionOpenDocumentTree/app/build.gradle
@@ -18,8 +18,6 @@ apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
 
-apply plugin: 'kotlin-android-extensions'
-
 android {
     compileSdkVersion 33
     defaultConfig {
@@ -37,7 +35,7 @@ android {
         }
     }
     namespace 'com.example.android.ktfiles'
-    /*
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -45,7 +43,11 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
-     */
+
+    buildFeatures{
+        viewBinding = true
+    }
+
 
 }
 

--- a/ActionOpenDocumentTree/app/build.gradle
+++ b/ActionOpenDocumentTree/app/build.gradle
@@ -36,6 +36,16 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    /*
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+    }
+     */
+
 }
 
 dependencies {

--- a/ActionOpenDocumentTree/app/build.gradle
+++ b/ActionOpenDocumentTree/app/build.gradle
@@ -21,11 +21,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 33
     defaultConfig {
         applicationId "com.example.android.ktfiles"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/ActionOpenDocumentTree/app/src/main/AndroidManifest.xml
+++ b/ActionOpenDocumentTree/app/src/main/AndroidManifest.xml
@@ -16,8 +16,7 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.example.android.ktfiles">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="true"

--- a/ActionOpenDocumentTree/app/src/main/AndroidManifest.xml
+++ b/ActionOpenDocumentTree/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
         <activity
             android:name="com.example.android.ktfiles.MainActivity"
             android:label="@string/app_name"
+            android:exported="true"
             android:theme="@style/Theme.DirSelect.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/ActionOpenDocumentTree/app/src/main/java/com/example/android/ktfiles/DirectoryFragment.kt
+++ b/ActionOpenDocumentTree/app/src/main/java/com/example/android/ktfiles/DirectoryFragment.kt
@@ -32,7 +32,6 @@ import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 

--- a/ActionOpenDocumentTree/app/src/main/java/com/example/android/ktfiles/DirectoryFragment.kt
+++ b/ActionOpenDocumentTree/app/src/main/java/com/example/android/ktfiles/DirectoryFragment.kt
@@ -31,6 +31,7 @@ import android.widget.Toast
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -54,8 +55,7 @@ class DirectoryFragment : Fragment() {
         directoryUri = arguments?.getString(ARG_DIRECTORY_URI)?.toUri()
             ?: throw IllegalArgumentException("Must pass URI of directory to open")
 
-        viewModel = ViewModelProviders.of(this)
-            .get(DirectoryFragmentViewModel::class.java)
+        viewModel = ViewModelProvider(this).get(DirectoryFragmentViewModel::class.java)
 
         val view = inflater.inflate(R.layout.fragment_directory, container, false)
         recyclerView = view.findViewById(R.id.list)
@@ -92,8 +92,8 @@ class DirectoryFragment : Fragment() {
         return view
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewStateRestored(savedInstanceState: Bundle?) {
+        super.onViewStateRestored(savedInstanceState)
 
         viewModel.loadDirectory(directoryUri)
     }

--- a/ActionOpenDocumentTree/app/src/main/java/com/example/android/ktfiles/MainActivity.kt
+++ b/ActionOpenDocumentTree/app/src/main/java/com/example/android/ktfiles/MainActivity.kt
@@ -25,8 +25,7 @@ import android.view.View
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.commit
-import com.google.android.material.floatingactionbutton.FloatingActionButton
-import kotlinx.android.synthetic.main.activity_main.toolbar
+import com.example.android.ktfiles.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
 
@@ -37,10 +36,12 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
-        setSupportActionBar(toolbar)
 
-        val openDirectoryButton = findViewById<FloatingActionButton>(R.id.fab_open_directory)
+        var binding: ActivityMainBinding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        setSupportActionBar(binding.toolbar)
+
+        val openDirectoryButton = binding.fabOpenDirectory
         openDirectoryButton.setOnClickListener {
             openDirectory()
         }
@@ -75,7 +76,6 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun openDirectory() {
-        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
         directoryPicker.launch(0)
     }
 
@@ -88,7 +88,7 @@ class MainActivity : AppCompatActivity() {
                 return null
             }
 
-            result?.let{result ->
+            result?.let{
                 val directoryUri = result.data as Uri
 
                 this@MainActivity.contentResolver.takePersistableUriPermission(

--- a/ActionOpenDocumentTree/app/src/main/java/com/example/android/ktfiles/MainActivity.kt
+++ b/ActionOpenDocumentTree/app/src/main/java/com/example/android/ktfiles/MainActivity.kt
@@ -89,7 +89,7 @@ class MainActivity : AppCompatActivity() {
             }
 
             result?.let{result ->
-                val directoryUri = result.data
+                val directoryUri = result.data as Uri
 
                 this@MainActivity.contentResolver.takePersistableUriPermission(
                     directoryUri,

--- a/ActionOpenDocumentTree/build.gradle
+++ b/ActionOpenDocumentTree/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     ext.kotlin_version = '1.5.30'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.1'
@@ -34,7 +34,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/ActionOpenDocumentTree/build.gradle
+++ b/ActionOpenDocumentTree/build.gradle
@@ -17,13 +17,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.5.30'
+    ext.kotlin_version = '1.6.21'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:8.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/ActionOpenDocumentTree/build.gradle
+++ b/ActionOpenDocumentTree/build.gradle
@@ -17,7 +17,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.6.21'
+    ext.kotlin_version = '1.8.21'
     repositories {
         google()
         mavenCentral()

--- a/ActionOpenDocumentTree/build.gradle
+++ b/ActionOpenDocumentTree/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.1'
+        classpath 'com.android.tools.build:gradle:7.0.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/ActionOpenDocumentTree/gradle.properties
+++ b/ActionOpenDocumentTree/gradle.properties
@@ -31,3 +31,6 @@ org.gradle.jvmargs=-Xmx1536m
 kotlin.code.style=official
 android.useAndroidX=true
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/ActionOpenDocumentTree/gradle/wrapper/gradle-wrapper.properties
+++ b/ActionOpenDocumentTree/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ActionOpenDocumentTree/gradle/wrapper/gradle-wrapper.properties
+++ b/ActionOpenDocumentTree/gradle/wrapper/gradle-wrapper.properties
@@ -1,22 +1,5 @@
-#
-# Copyright 2019 The Android Open Source Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-#Tue Oct 29 08:53:45 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip


### PR DESCRIPTION
Changes:
* MainActivity.kt: ActivityResultContract used in place of deprecated startActivityForResult
* MainActivity.kt: ViewModelsProvider used in place of deprecated ViewModelsProviders.of()
* Use Jetpack view binding in place of setContentView throughout
* build config: mavenCenteral not jcenter
* build config: update to Java 18.
* build config: build for Android SDK 33.
* build config: use Gradle 8.0.1
* build config: update all dependencies.